### PR TITLE
Update to base64url v3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -816,9 +816,9 @@
       "dev": true
     },
     "base64url": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
-      "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.0.tgz",
+      "integrity": "sha512-LIVmqIrIWuiqTvn4RzcrwCOuHo2DD6tKmKBPXXlr4p4n4l6BZBkwFTIa3zu1XkX5MbZgro4a6BvPi+n2Mns5Gg=="
     },
     "binary-extensions": {
       "version": "1.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsontokens",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "node.js library for encoding, decoding, and verifying JSON Web Tokens (JWTs)",
   "main": "lib/index.js",
   "scripts": {
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "asn1.js": "^4.9.1",
-    "base64url": "^2.0.0",
+    "base64url": "^3.0.0",
     "elliptic": "^6.3.2",
     "key-encoder": "^1.1.6",
     "validator": "^7.0.0"


### PR DESCRIPTION
This resolves #28 -- all tests continue to pass (the change in base64url was pretty minor -- using `Buffer.from` instead of `new Buffer`