### PR TITLE
Move type packages from devDependencies to dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2]
+- Fixed bug with type packages listed in `devDependencies` instead of `dependencies`.
+
 ## [2.0.1]
 - Added types to [TokenInterface](https://github.com/blockstack/jsontokens-js/issues/39).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jsontokens",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -134,16 +134,14 @@
       "version": "4.11.5",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.5.tgz",
       "integrity": "sha512-AEAZcIZga0JgVMHNtl1CprA/hXX7/wPt79AgR4XqaDt7jyj3QWYw6LPoOiznPtugDmlubUnAahMs2PFxGcQrng==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/elliptic": {
-      "version": "6.4.8",
-      "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.8.tgz",
-      "integrity": "sha512-1BaK+iQLH0c33RGRhE8gMbmMF1q4YUCzB4DbP7vz/Ohex0iP2NfOlJlZMDGkqu45IoMirUJe6KZfEdFtYPk1Kg==",
-      "dev": true,
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.9.tgz",
+      "integrity": "sha512-Mn+OyENd6YHwJKgUSyCTUDunEDFMaFpCXt52JCA00sxtzEa1ji6H0doZHL3iXhqMTo1Ob53X+Dv0s4PAJ+IVlA==",
       "requires": {
         "@types/bn.js": "*"
       }
@@ -151,8 +149,7 @@
     "@types/node": {
       "version": "10.14.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.8.tgz",
-      "integrity": "sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw==",
-      "dev": true
+      "integrity": "sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw=="
     },
     "@types/tape": {
       "version": "4.2.33",
@@ -1500,10 +1497,12 @@
       "dev": true
     },
     "key-encoder": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/key-encoder/-/key-encoder-2.0.1.tgz",
-      "integrity": "sha512-pcs8vr7KC+xq5WDEz84cK+yVvUARJpDqTB8gVYanEmhAchxjnbsGzk6SKzp+1O60WLywqOr3mjKf1CImPBWkNw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/key-encoder/-/key-encoder-2.0.2.tgz",
+      "integrity": "sha512-QgSbD+p0TehZAboWUnyjgMZd6E3cbcKbjzbqR9+MkW+gYpklOOkIgTsgVVoMT3syLWSkaIpvvjYOt4JYxGES1w==",
       "requires": {
+        "@types/bn.js": "^4.11.5",
+        "@types/elliptic": "^6.4.9",
         "asn1.js": "^5.0.1",
         "bn.js": "^4.11.8",
         "elliptic": "^6.4.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsontokens",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "node.js library for encoding, decoding, and verifying JSON Web Tokens (JWTs)",
   "main": "lib/index.js",
   "scripts": {
@@ -38,7 +38,6 @@
   },
   "homepage": "https://github.com/blockstack/jsontokens-js#readme",
   "devDependencies": {
-    "@types/elliptic": "^6.4.6",
     "@types/node": "^10.14.6",
     "@types/tape": "^4.2.33",
     "@typescript-eslint/eslint-plugin": "^1.9.0",
@@ -53,11 +52,12 @@
     "typescript": "^3.5.1"
   },
   "dependencies": {
+    "@types/elliptic": "^6.4.9",
     "asn1.js": "^5.0.1",
     "base64url": "^3.0.1",
     "ecdsa-sig-formatter": "^1.0.11",
     "elliptic": "^6.4.1",
-    "key-encoder": "^2.0.1"
+    "key-encoder": "^2.0.2"
   },
   "files": [
     "lib/",


### PR DESCRIPTION
Libs should do this so consumers don't need to install type dependencies.